### PR TITLE
progress and cli adjustments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,7 +32,7 @@ pub fn build_command() -> clap::Command {
                 .arg(
                     arg!([IN_DIRECTORY])
                         .value_parser(value_parser!(PathBuf))
-                        .required(true),
+                        .required(false),
                 ),
         )
         .subcommand(

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,6 +2,7 @@ use crate::cli::build_command;
 use crate::constants::physical_cores;
 use crate::pack::Pack;
 use crate::unpack::Unpack;
+use std::ffi::OsStr;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -12,18 +13,21 @@ pub enum PDFCon {
 
 pub fn get_command() -> PDFCon {
     let matches = build_command().get_matches();
-
     let total_physical = physical_cores();
+    let c_dir = std::env::current_dir().unwrap_or(PathBuf::from("./"));
+    let dir_name = c_dir.file_name().unwrap_or(OsStr::new("./"));
+    let default_name = c_dir.join(dir_name).with_extension("pdf");
+
     match matches.subcommand() {
         Some(("pack", sub_matches)) => PDFCon::PACK(Pack {
             optimize: sub_matches.get_flag("OPTIMIZE"),
             in_directory: sub_matches
                 .get_one::<PathBuf>("IN_DIRECTORY")
-                .unwrap()
+                .unwrap_or(&c_dir)
                 .to_owned(),
             out_file: sub_matches
                 .get_one::<PathBuf>("OUT_FILE")
-                .unwrap_or(&PathBuf::from("output.pdf"))
+                .unwrap_or(&default_name)
                 .to_owned(),
             threads: sub_matches
                 .get_one::<usize>("THREADS")

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,4 @@
+use console::Style;
 use num_cpus;
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -20,12 +21,42 @@ pub static IGNORE_LIST: &[&[u8]] = &[
 ];
 
 const THREADS: OnceLock<usize> = OnceLock::new();
+const TICK_SPEED: OnceLock<u64> = OnceLock::new();
 static CURRENT_DIR: OnceLock<PathBuf> = OnceLock::new();
+static BOLD: OnceLock<Style> = OnceLock::new();
+static C_GRAY: OnceLock<Style> = OnceLock::new();
+static BC_YELLOW: OnceLock<Style> = OnceLock::new();
+static BC_LGT_GREEN: OnceLock<Style> = OnceLock::new();
+static BC_GREEN: OnceLock<Style> = OnceLock::new();
+static BC_DRK_GREEN: OnceLock<Style> = OnceLock::new();
 
 pub fn physical_cores() -> usize {
     *THREADS.get_or_init(|| num_cpus::get_physical())
 }
 
+pub fn tick_speed() -> u64 {
+    *TICK_SPEED.get_or_init(|| 200)
+}
+
 pub fn current_dir() -> &'static PathBuf {
     CURRENT_DIR.get_or_init(|| std::env::current_dir().unwrap_or(PathBuf::from(".")))
+}
+
+pub fn bold() -> &'static Style {
+    BOLD.get_or_init(|| Style::new().bold())
+}
+pub fn c_gray() -> &'static Style {
+    C_GRAY.get_or_init(|| Style::new().color256(8))
+}
+pub fn bc_yellow() -> &'static Style {
+    BC_YELLOW.get_or_init(|| Style::new().yellow().bold())
+}
+pub fn bc_lgt_green() -> &'static Style {
+    BC_LGT_GREEN.get_or_init(|| Style::new().green().bold())
+}
+pub fn bc_green() -> &'static Style {
+    BC_GREEN.get_or_init(|| Style::new().color256(107).bold())
+}
+pub fn bc_drk_green() -> &'static Style {
+    BC_DRK_GREEN.get_or_init(|| Style::new().color256(65).bold())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod constants;
 pub mod error;
 pub mod pack;
 pub mod pdf_image;
+pub mod progress;
 pub mod unpack;
 
 pub trait Run {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,25 @@ use env_logger;
 use pdfcon::Run;
 use pdfcon::command;
 use pdfcon::error::PDFConError;
+use std::ffi::OsStr;
 
 fn main() -> Result<(), PDFConError> {
     env_logger::init();
     let command = command::get_command();
     match command {
-        command::PDFCon::PACK(p) => p.run(),
+        command::PDFCon::PACK(mut p) => {
+            if p.out_file.is_dir() {
+                // your dumb
+                log::error!("File name is a directory!");
+                std::process::exit(1);
+            }
+            let pdf_ext = OsStr::new("pdf");
+            if p.out_file.extension().unwrap_or(OsStr::new("")) != pdf_ext {
+                let temp = p.out_file.with_extension("pdf");
+                p.out_file = temp;
+            }
+            p.run()
+        }
         command::PDFCon::UNPACK(up) => up.run(),
     }
 }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,8 +1,9 @@
+use crate::constants::tick_speed;
 use crate::pdf_image;
+use crate::progress::{bar, close_bar, update_end_cap};
 use crate::{Run, error::PDFConError};
-use console::Style;
-use indicatif::{ParallelProgressIterator, ProgressStyle};
-use log::error;
+use indicatif::ParallelProgressIterator;
+use log::{debug, error};
 use lopdf::content::Content;
 use lopdf::{Document, Object, Stream, content::Operation, dictionary};
 use rayon::prelude::*;
@@ -101,7 +102,7 @@ impl Pack {
             "jpeg" | "jpg" => ImageType::JPG,
             _ => {
                 // File was not a supported image. This should be logged
-                error!("File type not supported");
+                debug!("File type not supported");
                 return None;
             }
         };
@@ -110,8 +111,6 @@ impl Pack {
     }
 
     fn para_process(&self) -> Result<(), PDFConError> {
-        let term = console::Term::stdout();
-
         let directory = std::fs::read_dir(&self.in_directory)?;
 
         let mut files: Vec<ImageFile> = directory
@@ -124,18 +123,19 @@ impl Pack {
 
         files.par_sort_by_key(|k| k.location.to_owned());
 
+        // Initialize the progress bar
+        let pb = bar("Converting to PDF", files.len() as u64, tick_speed());
+
         let pre_processed = files
             .par_iter()
-            .progress()
-            .with_prefix("⚡Processing Images")
-            .with_style(
-                ProgressStyle::with_template(
-                    format!("{{prefix}}: {{wide_bar}} {{pos}}/{{len}} ({{elapsed}})",).as_str(),
-                )
-                .unwrap_or(ProgressStyle::default_bar()),
-            )
-            .with_finish(indicatif::ProgressFinish::AndClear)
+            .progress_with(pb.clone())
             .filter_map(|image_file| {
+                let pos = pb.position();
+                let total = pb.length().unwrap();
+
+                // Update bars end cap based on current progress
+                update_end_cap(&pb, pos, total);
+
                 if self.optimize {
                     match self.optimize(image_file) {
                         Ok(bytes) => Some(bytes),
@@ -160,17 +160,8 @@ impl Pack {
             })
             .collect::<Vec<pdf_image::optimize::ImageData>>();
 
-        term.write_line(
-            format!(
-                "{}",
-                Style::new()
-                    .color256(82)
-                    .bold()
-                    .apply_to("Processing Finished ✓")
-                    .to_string(),
-            )
-            .as_str(),
-        )?;
+        // Finish bar and display message
+        close_bar(pb, " ● Converting Complete! ");
 
         // Use the latest PDF version
         let mut doc = Document::with_version("1.7");
@@ -333,6 +324,7 @@ impl Run for Pack {
         rayon::ThreadPoolBuilder::new()
             .num_threads(self.threads)
             .build_global()?;
+
         self.para_process()?;
         Ok(())
     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,61 @@
+use crate::constants::{bc_drk_green, bc_green, bc_lgt_green, bc_yellow, bold, c_gray};
+use console::Term;
+use indicatif::{ProgressBar, ProgressStyle};
+use log::error;
+
+pub fn bar(prefix: &str, total_progress: u64, tick_speed: u64) -> ProgressBar {
+    let pb = ProgressBar::new(total_progress);
+    pb.set_style(ProgressStyle::default_bar()
+                .progress_chars("█▓█")
+                .tick_strings(&["∙∙∙", "●∙∙", "∙●∙", "∙∙●", "∙∙●"])
+                .template(format!(
+                " {{spinner:.yellow.bold}} {{prefix:.yellow.bold}}{} {}{{wide_bar:.2.bold/:.65.bold}}{{msg}} {{percent:.green.bold}}{} {}{{pos:.8}}{}{{len:.8}}{} ",
+                bold().apply_to(":").to_string(),
+                bc_lgt_green().apply_to("").to_string(),
+                bc_lgt_green().apply_to("%").to_string(),
+                c_gray().apply_to("(").to_string(),
+                c_gray().apply_to("/").to_string(),
+                c_gray().apply_to(")").to_string()
+            ).as_str())
+        .unwrap_or(ProgressStyle::default_bar()));
+    pb.set_prefix(prefix.to_string());
+    pb.set_message(bc_drk_green().apply_to("").to_string());
+    pb.enable_steady_tick(std::time::Duration::from_millis(tick_speed));
+
+    return pb;
+}
+
+pub fn spinner(prefix: &str, tick_speed: u64) -> ProgressBar {
+    let spnr = ProgressBar::new_spinner();
+
+    spnr.set_style(ProgressStyle::default_spinner()
+                .tick_strings(&["∙∙∙", "●∙∙", "∙●∙", "∙∙●", "∙∙●"])
+                .template(format!(
+                " {{spinner:.yellow.bold}} {{prefix:.yellow.bold}} {{wide_msg}} {}{{elapsed:.8}}{} ",
+                c_gray().apply_to("(").to_string(),
+                c_gray().apply_to(")").to_string()
+            ).as_str())
+        .unwrap_or(ProgressStyle::default_spinner()));
+    spnr.set_prefix(prefix.to_string());
+    spnr.enable_steady_tick(std::time::Duration::from_millis(tick_speed));
+
+    return spnr;
+}
+
+pub fn update_end_cap(bar: &ProgressBar, pos: u64, total: u64) {
+    if pos >= total - 2 && pos < total {
+        bar.set_message(bc_green().apply_to("").to_string());
+    } else if pos == total {
+        bar.set_message(bc_lgt_green().apply_to("").to_string());
+    }
+}
+
+pub fn close_bar(bar: ProgressBar, msg: &str) {
+    bar.finish_and_clear();
+    match Term::stdout().write_line(format!("{}", bc_yellow().apply_to(msg)).as_str()) {
+        Ok(out) => out,
+        Err(_e) => {
+            error!("Failed to print to console");
+        }
+    }
+}

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -1,8 +1,9 @@
 use crate::Run;
-use crate::constants::IGNORE_LIST;
+use crate::constants::{IGNORE_LIST, tick_speed};
 use crate::error::PDFConError;
 use crate::pdf_image::{self, PDFConColorSpace};
-use indicatif::{ParallelProgressIterator, ProgressBar};
+use crate::progress::{bar, close_bar, spinner, update_end_cap};
+use indicatif::ParallelProgressIterator;
 use log::{debug, error};
 use lopdf::{Dictionary, Document, Object};
 use rayon::prelude::*;
@@ -42,6 +43,7 @@ impl Unpack {
         &self,
         doc: &Document,
         page_num: u32,
+        total_pages: usize,
         reference: &Object,
     ) -> Result<(), PDFConError> {
         debug!("Getting xobject information");
@@ -101,10 +103,13 @@ impl Unpack {
                     }
                 }
 
+                // Calculate needed zero padding for page names
+                let padding_width = (total_pages.ilog10() + 1) as usize;
                 let path = self.out_directory.join(format!(
-                    "{:0>5}.{}",
+                    "{:0width$}.{}",
                     page_num,
-                    if is_jpeg { "jpg" } else { "png" }
+                    if is_jpeg { "jpg" } else { "png" },
+                    width = padding_width
                 ));
 
                 if is_jpeg {
@@ -161,30 +166,43 @@ impl Unpack {
         doc: &Document,
         page_num: u32,
         page_dict: &Dictionary,
+        total_pages: usize,
     ) -> Result<(), PDFConError> {
         debug!("Getting resources and xobjects");
         let resources_dict = page_dict.get(b"Resources")?.as_dict()?;
         let x_obj_dict = resources_dict.get(b"XObject")?.as_dict()?;
         for (_name, x_ref) in x_obj_dict.iter() {
-            self.process_xobject(&doc, page_num, &x_ref)?;
+            self.process_xobject(&doc, page_num, total_pages, &x_ref)?;
         }
         Ok(())
     }
 
     fn extract_images(&self, doc: &Document) -> Result<(), PDFConError> {
-        let results: Vec<Result<(), PDFConError>> = doc
-            .get_pages()
-            .into_par_iter()
-            .collect::<Vec<_>>()
+        let pages = doc.get_pages().into_par_iter().collect::<Vec<_>>();
+        let total_pages = pages.len();
+
+        // Initialize the progress bar
+        let pb = bar("Processing Images", total_pages as u64, tick_speed());
+
+        let results: Vec<Result<(), PDFConError>> = pages
             .par_iter()
-            .progress()
+            .progress_with(pb.clone())
             .map(|(page_num, page_id)| {
+                let pos = pb.position();
+                let total = pb.length().unwrap();
+
+                // Update bars end cap based on current progress
+                update_end_cap(&pb, pos, total);
+
                 debug!("Getting page dict");
                 let page_dict = doc.get_object(*page_id)?.as_dict()?;
-                self.find_xobject_images_in_page(&doc, *page_num, &page_dict)?;
+                self.find_xobject_images_in_page(&doc, *page_num, &page_dict, total_pages)?;
                 Ok(())
             })
             .collect();
+
+        // Finish bar and display message
+        close_bar(pb, " ● Processing Complete! ");
 
         // Log any errors and return a general error
         let mut error_encountered = false;
@@ -209,18 +227,17 @@ impl Run for Unpack {
         rayon::ThreadPoolBuilder::new()
             .num_threads(self.threads)
             .build_global()?;
+
         std::fs::create_dir_all(&self.out_directory)?;
-        // This takes forever to complete and there is a possibility that it fails. Display a progressbar spinner while it runs
-        let pb_spinner = ProgressBar::new_spinner()
-            .with_style(
-                indicatif::ProgressStyle::with_template("{prefix}: {spinner}")
-                    .unwrap_or(indicatif::ProgressStyle::default_spinner())
-                    .tick_chars("▉▊▋▌▍▎▏▎▍▌▋▊▉"),
-            )
-            .with_prefix("Parsing PDF");
-        pb_spinner.enable_steady_tick(std::time::Duration::from_millis(500));
+
+        // Add spinner to show program is doing something
+        let spnr = spinner("Parsing PDF", tick_speed());
+
         let document = Document::load_filtered(&self.in_file, filter_func)?;
-        pb_spinner.finish();
+
+        // Finish bar and display message
+        close_bar(spnr, " ● Parsing Complete! ");
+
         self.extract_images(&document)?;
 
         Ok(())


### PR DESCRIPTION
- pack command now defaults to searching the current directory unless one is given
- pack command now defaults to the current directory name for the pdf name unless on is given
- pack command will now auto add the ".pdf" extension if it is not found
- unpack command now uses zero padding based on the total number of pages when naming files
- progress stuff has been moved to its own file/functions
- updated progress style to be more juicy